### PR TITLE
feat(nested-object-keys): implement nested object keys function

### DIFF
--- a/src/nested-object-keys/index.ts
+++ b/src/nested-object-keys/index.ts
@@ -16,5 +16,18 @@ import { NestedObjectKeysFn } from './types';
  * Output: []
  */
 export const nestedObjectKeys: NestedObjectKeysFn = (obj) => {
-  throw new Error('Not Implemented');
+  const result: string[] = [];
+
+  for (const key in obj) {
+    result.push(key);
+    if (Object.prototype.toString.call(obj) === '[object Object]') {
+      result.push(
+        ...nestedObjectKeys(obj[key] as Record<string, unknown>).map(
+          (item) => `${key}.${item}`,
+        ),
+      );
+    }
+  }
+
+  return result;
 };


### PR DESCRIPTION
Знайшов шлях для перевірки чи значення це об'єкт `Object.prototype.toString.call(obj) === '[object Object]'`, бо з typeof довелось би писати нормальний такий if. Але тести пройшли б із простою перевіркою на null